### PR TITLE
Добавлена опция уровня логирования

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spotify_in_russia"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clokwerk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify_in_russia"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["b3cat"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use structopt::StructOpt;
 struct CliOpts {
     #[structopt(short, long, default_value("./config.toml"))]
     config: std::path::PathBuf,
+    #[structopt(short, long, default_value("INFO"), env = "LOG_LEVEL")]
+    log_level: Level,
 }
 
 lazy_static! {
@@ -42,7 +44,7 @@ lazy_static! {
 }
 
 fn main() {
-    simple_logger::init_with_level(Level::Info).unwrap();
+    simple_logger::init_with_level(CLI_OPTS.log_level).unwrap();
 
     let SchedulerOpts { spy_check_interval, daily_check_time, east_offfset } = &CONFIG.scheduler;
     let tz = chrono::FixedOffset::east(*east_offfset);


### PR DESCRIPTION
Можно задать через параметр `--log-level` в консоли или переменную окружения `LOG_LEVEL`, параметр в приоритете. Доступные значение: `"OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"` Дефолтное значение – `INFO`, в случае некорректного значения не запустится, пример ошибки:
```
error: Invalid value for '--log-level <log-level>': attempted to convert a string that doesn't match an existing log level
```